### PR TITLE
Explicitly define img-src CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https:; img-src https: 'self'; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
+    Content-Security-Policy = "default-src https:; img-src https: 'self' data:image/svg+xml; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https:; img-src 'self'; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
+    Content-Security-Policy = "default-src https:; img-src https: 'self'; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https: data: ; img-src https: 'self' data: ; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
+    Content-Security-Policy = "default-src https: data: ; style-src 'self' 'unsafe-inline'; img-src https: 'self' data: ; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https:; img-src https: 'self' data:image/svg+xml; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
+    Content-Security-Policy = "default-src https:; img-src https: 'self' data: ; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https: data: ; style-src 'self' 'unsafe-inline'; img-src https: 'self' data: ; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
+    Content-Security-Policy = "default-src https: data: ; style-src https: 'self' 'unsafe-inline'; img-src https: 'self' data: ; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https:; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
+    Content-Security-Policy = "default-src https:; img-src 'self'; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,7 @@ command = "(env && make web HUGO=$(which hugo) WEBSITE_BASE_URL=${DEPLOY_PRIME_U
     # Force HTTPS only.
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     # Load scripts only via HTTPS and from allowed domains.
-    Content-Security-Policy = "default-src https:; img-src https: 'self' data: ; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
+    Content-Security-Policy = "default-src https: data: ; img-src https: 'self' data: ; script-src https: 'self' 'sha256-oU+PaCjPnzTPs1xK7UzMJThGMe9MQqUa+oy2tBLzRTo='; object-src 'self'"
     # Only send referred when HTTPS is used.
     Referrer-Policy = "strict-origin-when-cross-origin"
     # Disable certain magic features, lol.


### PR DESCRIPTION
This fixes #8 by explicitly defining the `img-src` CSP.

This is only an issue on Firefox because it needs explicit definition of CSPs.
When reviewing that content on Chrome it gets obvious: img-src is not explicitly defined, so we have a fallback to default-src.

```
Refused to load the image 'data:image/svg+xml,%3csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3e%3cpath stroke='rgba(255, 255, 255, 0.5)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e' because it violates the following Content Security Policy directive: "default-src https:". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.
```

While checking this with the [csp evaluator](https://csp-evaluator.withgoogle.com/) it shows that sooner or later we should look into the script source as well but this fixes a UI issue for now.
